### PR TITLE
ci: Change the way of working with secrets on  docker compose deploy

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -71,7 +71,29 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-      - name: Copy folder content recursively to remote
+      - uses: benjlevesque/short-sha@v1.2
+        id: short-sha
+        with:
+          length: 7
+      - name: create env
+        run: |
+              echo "POSTGRES_USER=${{ secrets.POSTGRES_USER }}" >> .env
+              echo "POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}" >> .env
+              echo "POSTGRES_DB=${{ secrets.POSTGRES_DB }}" >> .env
+              echo "SECRET_KEY=${{ secrets.SECRET_KEY }}" >> .env
+              echo "CELERY_BACKEND=db+postgresql://${{ secrets.POSTGRES_USER }}:${{ secrets.POSTGRES_PASSWORD }}@postgres/${{ secrets.POSTGRES_DB }}" >> .env
+              echo "IMAGE=docker.pkg.github.com/${{ github.repository }}/${{ secrets.IMAGE_NAME }}:sha-${{ steps.short-sha.outputs.sha }}" >> .env
+      - name: Copy .env
+        uses: garygrossgarten/github-action-scp@release
+        with:
+          local: .env
+          remote: ./git/.env
+          rmRemote: true
+          recursive: false
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.SSH_USER }}
+          privateKey: ${{ secrets.SSH_PRIVATE_KEY }}
+      - name: Copy docker-compose.deploy.yaml
         uses: garygrossgarten/github-action-scp@release
         with:
           local: ./docker-compose.deploy.yaml

--- a/docker-compose.deploy.yaml
+++ b/docker-compose.deploy.yaml
@@ -2,7 +2,7 @@ version: '3.7'
 
 services:
   app:
-    image: docker.pkg.github.com/open-contracting/spoonbill-web/app:latest
+    image: ${IMAGE}
     pull_policy: if_not_present
     command: sh -c "python manage.py collectstatic --noinput && python manage.py migrate && daphne -b 0.0.0.0 -p 8000 spoonbill_web.asgi:application"
     container_name: app
@@ -12,17 +12,14 @@ services:
     ports:
       - "80:8000"
     hostname: app
+    env_file:
+      - .env
     environment:
       - DEBUG=1
-      - SECRET_KEY=qgop1_i7%*3r9-=z-+_mz4r-!tool@(-a_r(g@k6jb6w5r13%m
       - DJANGO_ALLOWED_HOSTS=*
-      - CELERY_BROKER=redis://redis:6379/0
-      - CELERY_BACKEND=db+postgresql://spoonbilluser:spoonbillpwd@postgres/spoonbill
-      - POSTGRES_DB=spoonbill
-      - POSTGRES_USER=spoonbilluser
-      - POSTGRES_PASSWORD=spoonbillpwd
       - DB_HOST=postgres
       - REDIS_HOST=redis
+      - CELERY_BROKER=redis://redis:6379/0
     networks:
       - main
     volumes:
@@ -32,14 +29,10 @@ services:
     container_name: postgres
     hostname: postgres
     image: postgres:latest
-    environment:
-      - POSTGRES_USER=spoonbilluser
-      - POSTGRES_PASSWORD=spoonbillpwd
-      - POSTGRES_DB=spoonbill
+    env_file:
+      - .env
     networks:
       - main
-    ports:
-      - "5432:5432"
     restart: on-failure
     volumes:
       - postgresql-data:/var/lib/postgresql/data
@@ -50,23 +43,17 @@ services:
     networks:
       - main
     restart: on-failure
-    ports:
-      - "6379:6379"
   celery_worker:
-    image: docker.pkg.github.com/open-contracting/spoonbill-web/app:latest
+    image:  ${IMAGE}
     command: celery -A spoonbill_web worker -l INFO --concurrency=4
     container_name: celery_worker
+    env_file:
+      - .env
     environment:
       - DEBUG=1
-      - SECRET_KEY=qgop1_i7%*3r9-=z-+_mz4r-!tool@(-a_r(g@k6jb6w5r13%m
-      - DJANGO_ALLOWED_HOSTS=localhost 127.0.0.1 [::1]
-      - CELERY_BROKER=redis://redis:6379/0
-      - CELERY_BACKEND=db+postgresql://spoonbilluser:spoonbillpwd@postgres/spoonbill
-      - POSTGRES_DB=spoonbill
-      - POSTGRES_USER=spoonbilluser
-      - POSTGRES_PASSWORD=spoonbillpwd
       - DB_HOST=postgres
       - REDIS_HOST=redis
+      - CELERY_BROKER=redis://redis:6379/0
     depends_on:
       - app
       - postgres
@@ -78,19 +65,15 @@ services:
       - main
     restart: on-failure
   celery_beat:
-    image: docker.pkg.github.com/open-contracting/spoonbill-web/app:latest
+    image: ${IMAGE}
     command: celery -A spoonbill_web beat -l INFO --scheduler django_celery_beat.schedulers:DatabaseScheduler
     container_name: celery_beat
+    env_file:
+      - .env
     environment:
-      - DEBUG=1
-      - SECRET_KEY=qgop1_i7%*3r9-=z-+_mz4r-!tool@(-a_r(g@k6jb6w5r13%m
-      - DJANGO_ALLOWED_HOSTS=localhost 127.0.0.1 [::1]
-      - CELERY_BROKER=redis://redis:6379/0
-      - CELERY_BACKEND=db+postgresql://spoonbilluser:spoonbillpwd@postgres/spoonbill
-      - POSTGRES_DB=spoonbill
-      - POSTGRES_USER=spoonbilluser
-      - POSTGRES_PASSWORD=spoonbillpwd
       - DB_HOST=postgres
+      - REDIS_HOST=redis
+      - CELERY_BROKER=redis://redis:6379/0
     depends_on:
       - app
       - postgres


### PR DESCRIPTION
The docker-compose.deploy.yaml file now uses secrets from .env that are created and deployed by CI.