### PR TITLE
Fix code scanning alert no. 2: Incomplete string escaping or encoding

### DIFF
--- a/frontend/src/utils/getQueryParam.js
+++ b/frontend/src/utils/getQueryParam.js
@@ -1,5 +1,5 @@
 export default (name) => {
-    name = name.replace(/[[]/, '\\[').replace(/[\]]/, '\\]');
+    name = name.replace(/\[/g, '\\[').replace(/\]/g, '\\]');
     const regex = new RegExp('[\\?&]' + name + '=([^&#]*)');
     const results = regex.exec(window.location.hash);
     return results === null ? '' : decodeURIComponent(results[1].replace(/\+/g, ' '));


### PR DESCRIPTION
Fixes [https://github.com/open-contracting/spoonbill-web/security/code-scanning/2](https://github.com/open-contracting/spoonbill-web/security/code-scanning/2)

To fix the problem, we need to ensure that all occurrences of the characters `[` and `]` in the `name` variable are properly escaped. This can be achieved by using the global flag (`g`) in the regular expressions. This way, all instances of the characters will be replaced, not just the first one.

We will modify the `replace` method calls on line 2 to use regular expressions with the global flag.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
